### PR TITLE
Add badge and cancel button

### DIFF
--- a/src/routes/Rockets.js
+++ b/src/routes/Rockets.js
@@ -34,7 +34,7 @@ const Rockets = () => {
                     dispatch(reserveRocket(id));
                   }}
                 >
-                  {reserved ? 'Reserved' : 'Reserve Rocket'}
+                  {reserved ? 'Cancel Reservation' : 'Reserve Rocket'}
                 </button>
               </div>
             </li>

--- a/src/styles/rockets.css
+++ b/src/styles/rockets.css
@@ -46,5 +46,9 @@
 }
 
 .reserved-tag {
-  color: red;
+  font-size: 10px;
+  padding: 2px 5px;
+  color: white;
+  background: #19a2b9;
+  border-radius: 5px;
 }


### PR DESCRIPTION
- Rockets that have already been reserved should show a "Reserved" badge and "Cancel reservation" button instead of the default "Reserve rocket" (as per design)
Use the React conditional rendering syntax:
```
{rocket.reserved && ( 
    // render Cancel Rocket button
)}
```