### PR TITLE
switch badges for missions status

### DIFF
--- a/src/routes/Missions.js
+++ b/src/routes/Missions.js
@@ -30,7 +30,11 @@ const Missions = () => {
           <tr>
             <td>{dat.mission_name}</td>
             <td>{dat.description}</td>
-            <td>Not a member</td>
+            {!dat.reserved ? (
+              <td>Not a member</td>
+            ) : (
+              <td>ACTIVE MEMBER</td>
+            )}
             <td>
               {!dat.reserved ? (
                 <button type="button" key={dat.mission_id} onClick={() => joinMission(dat.mission_id)}>

--- a/src/styles/missions.css
+++ b/src/styles/missions.css
@@ -17,3 +17,23 @@ th {
 tr:nth-child(even) {
   background-color: #ddd;
 }
+
+button {
+  background-color: #0095ff; /* Green */
+  border: none;
+  border-radius: 5px;
+  color: white;
+  padding: 0.5rem 1rem;
+  text-align: center;
+  text-decoration: none;
+  cursor: pointer;
+  box-shadow: 5px 7px 19px -7px rgba(0, 0, 0, 0.68);
+}
+
+button:hover {
+  background-color: #06f;
+}
+
+button:active {
+  transform: translate(1px, 1px);
+}


### PR DESCRIPTION
Hello!

for this milestone, I make these changes:

Missions that the user has joined already show a badge "Active Member" instead of the default "NOT A MEMBER" and a button "Leave Mission" instead of the "Join Mission" button.

